### PR TITLE
PLAT-112863:-Upgrading versions of dependencies to comply with INFA Security standards

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0</version>
+  <version>1.1.2</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.2</version>
     </dependency>
 
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.6</version>
+  <version>1.1.8</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.6</version>
+      <version>1.1.8</version>
     </dependency>
 
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>1.1.4</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.4</version>
     </dependency>
 
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.4</version>
+  <version>1.1.6</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.4</version>
+      <version>1.1.6</version>
     </dependency>
 
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.8</version>
+  <version>1.1.10</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.8</version>
+      <version>1.1.10</version>
     </dependency>
 
     <dependency>

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>
@@ -96,6 +96,14 @@
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -103,14 +111,14 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.59.Final</version>
+            <version>4.1.63.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.netty/netty-transport-native-epoll -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.59.Final</version>
+            <version>4.1.63.Final</version>
         </dependency>
         
 
@@ -226,6 +234,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -248,6 +260,14 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -137,28 +137,28 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.36.v20210114</version>
+            <version>11.0.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-util -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.36.v20210114</version>
+            <version>11.0.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.36.v20210114</version>
+            <version>11.0.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-webapp -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.4.36.v20210114</version>
+            <version>11.0.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>
@@ -91,6 +91,10 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -186,6 +190,12 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>8.19</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.8</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>
@@ -104,6 +104,10 @@
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -112,6 +116,13 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.1.63.Final</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.21</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.netty/netty-transport-native-epoll -->

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.10</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.63.Final</version>
+            <version>4.1.70.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.63.Final</version>
+            <version>4.1.70.Final</version>
         </dependency>
         
 

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>


### PR DESCRIPTION
```
We have found a security vulnerabilities during security scan for December release in AEP jars ecosystem-examples-1.1.8.jar & example-parquetIO-1.1.8.jar.
 

Vulnerable version: 4.1.63.Final of Netty Project  - Best Recommended Version : 4.1.70.Final
Paths:
·       package/connectors/ctk/604301/ecosystem-examples-1.1.8.jar!//io/netty/util/
·       package/connectors/ctk/604301/ecosystem-examples-1.1.8.jar!//io/netty/handler/timeout/
·       package/connectors/ctk/604301/ecosystem-examples-1.1.8.jar!//io/netty/handler/pcap/
·       package/connectors/ctk/604301/example-parquetIO-1.1.8.jar!//io/netty/channel/epoll/
·       package/connectors/ctk/604301/example-parquetIO-1.1.8.jar!//io/netty/channel/socket/
·       package/connectors/ctk/604301/ecosystem-examples-1.1.8.jar!//io/netty/channel/nio/
List of CVE's:

CVE-2021-37136 (BDSA-2021-2832) CVE-2021-37137 (BDSA-2021-2831)
```
