### PR TITLE
PLAT-119999:- Upgrading versions of dependencies to comply with INFA Security standards

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.adobe.platform</groupId>
   <artifactId>ecosystem-examples</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.14</version>
+  <version>1.1.16</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.adobe.platform</groupId>
       <artifactId>example-parquetIO</artifactId>
-      <version>1.1.14</version>
+      <version>1.1.16</version>
     </dependency>
 
     <dependency>

--- a/parquetio/pom.xml
+++ b/parquetio/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.adobe.platform</groupId>
     <artifactId>example-parquetIO</artifactId>
-    <version>1.1.14</version>
+    <version>1.1.16</version>
     <packaging>jar</packaging>
     <description>This jar will take care conversion of CSV to Parquet &amp; vice-versa</description>
     <properties>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.70.Final</version>
+            <version>4.1.75.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.70.Final</version>
+            <version>4.1.75.Final</version>
         </dependency>
         
 


### PR DESCRIPTION
Vulnerable version: 4.1.70.Final of Netty Project - Best Recommended Version : 4.1.75.Final
Paths:
package-AdobeExperiencePlatformConnector.38050019.zip/package/connectors/ctk/604301/ecosystem-examples-1.1.10.jar/io/netty/buffer
package-AdobeExperiencePlatformConnector.38050019.zip/package/connectors/ctk/604301/example-parquetIO-1.1.10.jar/io/netty/buffer/

List of CVE's:CVE-2021-43797
